### PR TITLE
Delete CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @ministryofjustice/analytics-hq


### PR DESCRIPTION
Deleted because I'm not a fan of having a codeowners file. I've previously deleted this setting in most other AP repos, so this change brings it into line.

The problem is that it means everyone in the github team get invited to do a review of every PR automatically. I can't turn off the notifications that come from these PR review invites. And neither can anyone else. I think it makes more sense for PR authors to manually invite the particular people who are relevant to each PR. (And if someone does happen to be interested in every PR from a repo, then they can choose to follow the repo.) When we configure lots of unsolicited notifications like this, it means people end up turning off **all** notifications, and miss important things including mentions, which is the worst outcome.