### PR TITLE
ANPL-1294 - Set option to sanitize error messages

### DIFF
--- a/R/runServer.R
+++ b/R/runServer.R
@@ -6,5 +6,8 @@ SCRIPT_DIR <- Sys.getenv('DIRNAME')
 # Add an HTTP filter to inject SockJS scripts etc into the Shiny app's HTML responses
 source(paste(SCRIPT_DIR, '/R/injectSockJS.R', sep=''))
 
+# Ensure that we don't send verbose error messages back to the client
+options(shiny.sanitize.errors = TRUE)
+
 # Actually serve the app
 shiny::runApp(SHINY_APP, port=PORT, launch.browser=FALSE)


### PR DESCRIPTION
Currently when shiny apps generate an error, they will send verbose output to the browser, often containing source code and other potentially sensitive information.

According to the documentation at
https://shiny.rstudio.com/articles/sanitize-errors.html#:~:text=To%20sanitize%20errors%20everywhere%20in,in%20the%20next%20section)%3A this PR will globally set an option to make RShiny sanitize errors sent to the browser by sending a generic error page.  Errors/Stacks will still be logged to the server.

Fixes https://dsdmoj.atlassian.net/browse/ANPL-1294
